### PR TITLE
use can save a new algorithm submission and work on it later; fronten…

### DIFF
--- a/client/components/user-new-algorithm-submission-page/index.js
+++ b/client/components/user-new-algorithm-submission-page/index.js
@@ -1,232 +1,324 @@
 import React, { Component } from 'react'
-import { postAlgorithmValidationInput } from '../../store'
+import { postAlgorithmValidationInput, postUserAlgorithmQuestion } from '../../store'
 import { connect } from 'react-redux'
 import AceEditor from 'react-ace'
 import 'brace/mode/python'
 import 'brace/mode/javascript'
 import 'brace/theme/chrome'
+import { setTimeout } from 'timers';
 
 class UserAlgorithmSubmissionPage extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      algorithmName: '',
-      category: '',
-      difficulty: '',
-      localDescriptionInput: '',
-      localAlgorithmInput: '',
-      result: '',
-      outputMode: 'TestCases',
-      localTestInput: '',
-      algorithmCategory: '',
-      algorithmDifficulty: '',
-      algorithmLanguage: 'javascript',
-      algorithmFunctionName: ''
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            algorithmName: '',
+            category: '',
+            difficulty: '',
+            localDescriptionInput: '',
+            localAlgorithmInput: '',
+            result: '',
+            outputMode: 'TestCases',
+            localTestInput: '',
+            algorithmCategory: '',
+            algorithmDifficulty: '',
+            algorithmLanguage: 'javascript',
+            algorithmFunctionName: '',
+            needFunctionName: false,
+            needAlgorithmName: false,
+            colorValidationButton: false,
+            needDescription: false
+        }
+
+        this.setAlgorithmName = this.setAlgorithmName.bind(this)
+        this.setAlgorithmCategory = this.setAlgorithmCategory.bind(this)
+        this.setAlgorithmDifficulty = this.setAlgorithmDifficulty.bind(this)
+        this.setAlgorithmLanguage = this.setAlgorithmLanguage.bind(this)
+        this.setLocalDescriptionInput = this.setLocalDescriptionInput.bind(this)
+        this.onSolutionChange = this.onSolutionChange.bind(this)
+        this.onTestChange = this.onTestChange.bind(this)
+        this.onValidate = this.onValidate.bind(this)
+        this.onSave = this.onSave.bind(this)
+        this.handleOutputMode = this.handleOutputMode.bind(this)
+        this.setAlgorithmFunctionName = this.setAlgorithmFunctionName.bind(this)
     }
-    this.setAlgorithmName = this.setAlgorithmName.bind(this)
-    this.setAlgorithmCategory = this.setAlgorithmCategory.bind(this)
-    this.setAlgorithmDifficulty = this.setAlgorithmDifficulty.bind(this)
-    this.setAlgorithmLanguage = this.setAlgorithmLanguage.bind(this)
-    this.setLocalDescriptionInput = this.setLocalDescriptionInput.bind(this)
-    this.onSolutionChange = this.onSolutionChange.bind(this)
-    this.onTestChange = this.onTestChange.bind(this)
-    this.onValidate = this.onValidate.bind(this)
-    this.handleOutputMode = this.handleOutputMode.bind(this)
-    this.setAlgorithmFunctionName = this.setAlgorithmFunctionName.bind(this)
-  }
 
-  setAlgorithmName(event) {
-    this.setState({ algorithmName: event.target.value })
-  }
+    setAlgorithmName(event) {
 
-  setAlgorithmCategory(event) {
-    this.setState({ algorithmCategory: event.target.value })
-  }
+        const promisifiedSetAlgorithmName = new Promise((resolve) => {
+            resolve(this.setState({ algorithmName: event.target.value }))
+        })
 
-  setAlgorithmDifficulty(event) {
-    this.setState({ algorithmDifficulty: event.target.value })
-  }
+        promisifiedSetAlgorithmName.then(() => {
+            if (!this.state.algorithmName) {
+                this.setState({ needAlgorithmName: true })
+            } else {
+                this.setState({ needAlgorithmName: false })
+            }
+        })
 
-  setAlgorithmLanguage(event) {
-    this.setState({ algorithmLanguage: event.target.value })
-  }
-
-  setAlgorithmFunctionName(event) {
-    this.setState({ algorithmFunctionName: event.target.value })
-  }
-
-  setLocalDescriptionInput(event) {
-    this.setState({ localDescriptionInput: event.target.value })
-  }
-
-  onSolutionChange(newValue) {
-    this.setState({ localAlgorithmInput: newValue })
-  }
-
-  onTestChange(newValue) {
-    this.setState({ localTestInput: newValue })
-  }
-
-  onValidate(event) {
-    event.preventDefault()
-    if (this.state.algorithmFunctionName) {
-      this.props.toPostAlgorithmValidationSubmission(
-        {
-          algorithmInput: this.state.localAlgorithmInput,
-          language: this.state.algorithmLanguage,
-          functionName: this.state.algorithmFunctionName,
-          testFile: this.state.localTestInput
-        },
-        this.props.user
-      )
-    } else {
-      console.log("I am desperate!!!!")
     }
-  }
 
-  handleOutputMode(event) {
-    if (event.target.textContent === 'Validation Custom Output') {
-      this.setState({ outputMode: 'ValidationCustomOutput' })
-    } else if (event.target.textContent === 'Test Cases') {
-      this.setState({ outputMode: 'TestCases' })
-    } else if (event.target.textContent === 'Validation Raw Output') {
-      this.setState({ outputMode: 'ValidationRawOutput' })
+    setAlgorithmCategory(event) {
+        this.setState({ algorithmCategory: event.target.value })
     }
-  }
 
-  render() {
-    const { difficulties, categories, validationCustomResult, validationResult } = this.props
+    setAlgorithmDifficulty(event) {
+        this.setState({ algorithmDifficulty: event.target.value })
+    }
 
-    return (
-      <div id="submission-page" >
-        <div id="submission-control-buttons-container">
-          <button>Save</button>
-          <button>Reset</button>
-          <button>Publish</button>
-          <button>Delete</button>
-        </div>
-        <div id="question-info">
-          <div id="submission-info-form-container">
-            <div className="input-row"><label>Name</label><input onChange={this.setAlgorithmName} value={this.state.algorithmName} /></div>
-            <div className="input-row">
-              <label>Category</label>
-              <select onChange={this.setAlgorithmCategory}>
-                {categories && categories.map(category => (
-                  <option key={category.id} value={category.name}>{category.name}</option>
-                ))}
-              </select>
-            </div>
-            <div className="input-row">
-              <label>Estimated Difficulty</label>
-              <select onChange={this.setAlgorithmDifficulty}>
-                {difficulties && difficulties.map(difficulty => (
-                  <option key={difficulty.id} value={difficulty.name}>{difficulty.name}</option>
-                ))}
-              </select>
-            </div>
-            <div className="input-row">
-              <label>Language</label>
-              <select onChange={this.setAlgorithmLanguage} value={this.state.algorithmLanguage}>
-                <option value="python">python</option>
-                <option value="javascript">javascript</option>
-              </select>
-            </div>
-            <div className="input-row">
-              <label>Entry Function Name</label>
-              <input onChange={this.setAlgorithmFunctionName} value={this.state.algorithmFunctionName} />
-            </div>
-          </div>
-          <div id="description-container">
-            <div id="description-title">Description</div>
-            <div>
-              <textarea onChange={this.setLocalDescriptionInput} value={this.state.localDescriptionInput} />
-            </div>
-          </div>
-        </div>
-        <div id="solution-test-container">
-          <div id="submission-solution">
-            <div id="validate-button-container">
-              <button onClick={this.onValidate}>Validate Solution</button>
-            </div>
-            <div id="submission-code-editor">
-              <AceEditor
-                className="ace-editor"
-                mode={this.state.algorithmLanguage}
-                theme="chrome"
-                onChange={this.onSolutionChange}
-                value={this.state.localAlgorithmInput}
-                name="algorithm-input"
-                editorProps={{ $blockScrolling: true }}
-                width="100%"
-              />
-            </div>
-          </div>
-          <div id="test-solution">
-            <div id="tests-button-container">
-              <button onClick={this.handleOutputMode} style={this.state.outputMode === 'TestCases' ? { border: '1px solid black', borderBottom: 'none' } : {}}>Test Cases</button>
-              <button onClick={this.handleOutputMode} style={this.state.outputMode === 'ValidationCustomOutput' ? { border: '1px solid black', borderBottom: 'none' } : {}}>Validation Custom Output</button>
-              <button onClick={this.handleOutputMode} style={this.state.outputMode === 'ValidationRawOutput' ? { border: '1px solid black', borderBottom: 'none' } : {}}>Validation Raw Output</button>
-            </div>
-            {
-              this.state.outputMode === 'TestCases'
-                ? <div className="submission-test-code-editor">
-                  <AceEditor
-                    className="ace-test-editor"
-                    mode={this.state.algorithmLanguage}
-                    theme="chrome"
-                    onChange={this.onTestChange}
-                    value={this.state.localTestInput}
-                    name="test-input"
-                    editorProps={{ $blockScrolling: true }}
-                    width="100%"
-                  />
-                </div>
-                : ''
+    setAlgorithmLanguage(event) {
+        this.setState({ algorithmLanguage: event.target.value })
+    }
+
+    setAlgorithmFunctionName(event) {
+
+        const promisifiedSetFunctionName = new Promise((resolve) => {
+            resolve(this.setState({ algorithmFunctionName: event.target.value }))
+        })
+
+        promisifiedSetFunctionName.then(() => {
+            if (!this.state.algorithmFunctionName) {
+                this.setState({ needFunctionName: true })
+            } else {
+                this.setState({ needFunctionName: false })
             }
-            {
-              this.state.outputMode === 'ValidationCustomOutput'
-                ? <div className="scroll-viewer" >
-                  <pre className="raw-output">
-                    {validationCustomResult.map(result => (
-                      <p key={result.title + ' ' + result.outcome} style={result.outcome === 'passed' ? { color: 'green' } : { color: 'red' }}>{result.title + ' ' + result.outcome}</p>
-                    )
-                    )}
-                  </pre>
-                </div>
-                : ''
+        })
+
+    }
+
+    setLocalDescriptionInput(event) {
+        this.setState({ localDescriptionInput: event.target.value })
+    }
+
+    handleOutputMode(event) {
+        if (event.target.textContent === 'Validation Custom Output') {
+            this.setState({ outputMode: 'ValidationCustomOutput' })
+        } else if (event.target.textContent === 'Test Cases') {
+            this.setState({ outputMode: 'TestCases' })
+        } else if (event.target.textContent === 'Validation Raw Output') {
+            this.setState({ outputMode: 'ValidationRawOutput' })
+        }
+    }
+
+    onSolutionChange(newValue) {
+        this.setState({ localAlgorithmInput: newValue })
+    }
+
+    onTestChange(newValue) {
+        this.setState({ localTestInput: newValue })
+    }
+
+    onValidate(event) {
+
+        event.preventDefault()
+
+        if (this.state.algorithmFunctionName) {
+
+            this.setState({ colorValidationButton: true })
+
+            setTimeout(() => {
+                this.setState({ colorValidationButton: false })
+            }, 50)
+
+            this.props.toPostAlgorithmValidationSubmission(
+                {
+                    algorithmInput: this.state.localAlgorithmInput,
+                    language: this.state.algorithmLanguage,
+                    functionName: this.state.algorithmFunctionName,
+                    testFile: this.state.localTestInput
+                },
+                this.props.user
+            )
+
+            this.setState({ outputMode: 'ValidationCustomOutput' })
+
+        } else {
+            this.setState({ needFunctionName: true })
+        }
+    }
+
+    onSave(event) {
+        event.preventDefault()
+
+        if (this.state.algorithmName) {
+
+            let algorithmSubmissionObj = {}
+            //also check if there is an existing question with an ID!!!!!
+            
+            if (this.state.algorithmLanguage === 'javascript') {
+
+                algorithmSubmissionObj = {
+                    name: this.state.algorithmName,
+                    javascriptSolution: this.state.localAlgorithmInput,
+                    functionName: this.state.algorithmFunctionName,
+                    javascriptTestFile: this.state.localTestInput,
+                    description: this.state.localDescriptionInput,
+                    difficulty: this.state.algorithmDifficulty,
+                    category: this.state.algorithmCategory,
+                    published: false,
+                    userId: this.props.user.id
+                }
+
+            } else if (this.state.algorithmLanguage === 'python') {
+
+                algorithmSubmissionObj = {
+                    name: this.state.algorithmName,
+                    javascriptSolution: this.state.localAlgorithmInput,
+                    functionName: this.state.algorithmFunctionName,
+                    javascriptTestFile: this.state.localTestInput,
+                    description: this.state.localDescriptionInput,
+                    difficulty: this.state.algorithmDifficulty,
+                    category: this.state.algorithmCategory,
+                    published: false,
+                    userId: this.props.user.id
+                }
+
             }
-            {
-              this.state.outputMode === 'ValidationRawOutput'
-                ? <div className="scroll-viewer">
-                  <pre className="raw-output">
-                    {validationResult}
-                  </pre>
+
+            this.props.toPostUserAlgorithmQuestion(algorithmSubmissionObj)
+
+        } else {
+            this.setState({ needAlgorithmName: true })
+        }
+    }
+
+    /* eslint-disable complexity */
+    render() {
+
+        const { difficulties, categories, validationCustomResult, validationResult } = this.props
+
+        return (
+            <div id="submission-page" >
+                <div id="submission-control-buttons-container">
+                    <button onClick={this.onSave}>Save</button>
+                    <button>Reset</button>
+                    <button>Publish</button>
+                    <button>Delete</button>
                 </div>
-                : ''
-            }
-          </div>
-        </div>
-      </div>
-    )
-  }
+                <div id="question-info">
+                    <div id="submission-info-form-container">
+                        <div className="input-row"><label>Name{this.state.needAlgorithmName ? <span style={{ color: 'red' }}> required</span> : ''}</label><input onChange={this.setAlgorithmName} value={this.state.algorithmName} /></div>
+                        <div className="input-row">
+                            <label>Category</label>
+                            <select onChange={this.setAlgorithmCategory}>
+                                {categories && categories.map(category => (
+                                    <option key={category.id} value={category.name}>{category.name}</option>
+                                ))}
+                            </select>
+                        </div>
+                        <div className="input-row">
+                            <label>Estimated Difficulty</label>
+                            <select onChange={this.setAlgorithmDifficulty}>
+                                {difficulties && difficulties.map(difficulty => (
+                                    <option key={difficulty.id} value={difficulty.name}>{difficulty.name}</option>
+                                ))}
+                            </select>
+                        </div>
+                        <div className="input-row">
+                            <label>Language</label>
+                            <select onChange={this.setAlgorithmLanguage} value={this.state.algorithmLanguage}>
+                                <option value="python">python</option>
+                                <option value="javascript">javascript</option>
+                            </select>
+                        </div>
+                        <div className="input-row">
+                            <label>Export Function Name{this.state.needFunctionName ? <span style={{ color: 'red' }}> required</span> : ''}</label>
+                            <input onChange={this.setAlgorithmFunctionName} value={this.state.algorithmFunctionName} />
+                        </div>
+                    </div>
+                    <div id="description-container">
+                        <div id="description-title">Description</div>
+                        <div>
+                            <textarea onChange={this.setLocalDescriptionInput} value={this.state.localDescriptionInput} />
+                        </div>
+                    </div>
+                </div>
+                <div id="solution-test-container">
+                    <div id="submission-solution">
+                        <div id="validate-button-container">
+                            <button onClick={this.onValidate} style={this.state.colorValidationButton ? { backgroundColor: 'green' } : {}}>Validate Solution</button>
+                        </div>
+                        <div id="submission-code-editor">
+                            <AceEditor
+                                className="ace-editor"
+                                mode={this.state.algorithmLanguage}
+                                theme="chrome"
+                                onChange={this.onSolutionChange}
+                                value={this.state.localAlgorithmInput}
+                                name="algorithm-input"
+                                editorProps={{ $blockScrolling: true }}
+                                width="100%"
+                            />
+                        </div>
+                    </div>
+                    <div id="test-solution">
+                        <div id="tests-button-container">
+                            <button onClick={this.handleOutputMode} style={this.state.outputMode === 'TestCases' ? { border: '1px solid black', borderBottom: 'none' } : {}}>Test Cases</button>
+                            <button onClick={this.handleOutputMode} style={this.state.outputMode === 'ValidationCustomOutput' ? { border: '1px solid black', borderBottom: 'none' } : {}}>Validation Custom Output</button>
+                            <button onClick={this.handleOutputMode} style={this.state.outputMode === 'ValidationRawOutput' ? { border: '1px solid black', borderBottom: 'none' } : {}}>Validation Raw Output</button>
+                        </div>
+                        {
+                            this.state.outputMode === 'TestCases'
+                                ? <div id="submission-test-code-editor">
+                                    <AceEditor
+                                        className="ace-test-editor"
+                                        mode={this.state.algorithmLanguage}
+                                        theme="chrome"
+                                        onChange={this.onTestChange}
+                                        value={this.state.localTestInput}
+                                        name="test-input"
+                                        editorProps={{ $blockScrolling: true }}
+                                        width="100%"
+                                    />
+                                </div>
+                                : ''
+                        }
+                        {
+                            this.state.outputMode === 'ValidationCustomOutput'
+                                ? <div className="scroll-viewer" >
+                                    <pre className="raw-output">
+                                        {validationCustomResult.map(result => (
+                                            <p key={result.title + ' ' + result.outcome} style={result.outcome === 'passed' ? { color: 'green' } : { color: 'red' }}>{result.title + ' ' + result.outcome}</p>
+                                        )
+                                        )}
+                                    </pre>
+                                </div>
+                                : ''
+                        }
+                        {
+                            this.state.outputMode === 'ValidationRawOutput'
+                                ? <div className="scroll-viewer">
+                                    <pre className="raw-output">
+                                        {validationResult}
+                                    </pre>
+                                </div>
+                                : ''
+                        }
+                    </div>
+                </div>
+            </div>
+        )
+    }
 }
 
 const mapState = state => {
-  return {
-    user: state.user,
-    categories: state.categories,
-    difficulties: state.difficulties,
-    validationResult: state.validationResult,
-    validationCustomResult: state.validationCustomResult,
-
-  }
+    return {
+        user: state.user,
+        categories: state.categories,
+        difficulties: state.difficulties,
+        validationResult: state.validationResult,
+        validationCustomResult: state.validationCustomResult,
+    }
 }
 
 const mapDispatch = dispatch => {
-  return {
-    toPostAlgorithmValidationSubmission: (submission, user) =>
-      dispatch(postAlgorithmValidationInput(submission, user))
-  }
+    return {
+        toPostAlgorithmValidationSubmission: (submission, user) =>
+            dispatch(postAlgorithmValidationInput(submission, user)),
+        toPostUserAlgorithmQuestion: (questionSubmission) =>
+            dispatch(postUserAlgorithmQuestion(questionSubmission))
+    }
 }
 
 export default connect(mapState, mapDispatch)(UserAlgorithmSubmissionPage)

--- a/client/index.scss
+++ b/client/index.scss
@@ -1,815 +1,870 @@
 * {
-  box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 body {
-  font-family: sans-serif;
-  a {
-    text-decoration: none;
-  }
-  label {
-    display: block;
-  }
-  nav a {
-    display: inline-block;
-    margin: 1em;
-  }
-  form div {
-    margin: 1em;
-    display: inline-block;
-  }
+    font-family: sans-serif;
+
+    a {
+        text-decoration: none;
+    }
+
+    label {
+        display: block;
+    }
+
+    nav a {
+        display: inline-block;
+        margin: 1em;
+    }
+
+    form div {
+        margin: 1em;
+        display: inline-block;
+    }
 }
 
 #app {
-  height: 100vh;
-  width: 100vw;
-  .navbar {
+    height: 100vh;
     width: 100vw;
-    height: 30px;
-    margin-bottom: 40px;
-    display: flex;
-    .navbar-central {
-      width: calc(100vw - 200px - 250px);
-      display: flex;
-      justify-content: center;
-      height: 30px;
-      #head-link {
+
+    .navbar {
+        width: 100vw;
         height: 30px;
-        #head {
-          font-size: 16px;
-          color: black;
-          font-style: italic;
-          height: 30px;
-          width: 15vw;
-          outline: none;
-          border: none;
-          background-color: white;
-        }
-      }
-    }
-    .navbar-left {
-      width: 250px;
-      display: flex;
-      padding-left: 3vw;
-      height: 30px;
-      .link {
-        margin-right: 10px;
-        margin-top: 15px;
-        margin-bottom: 0px;
-        color: black;
-        .small-head {
-          font-size: 13px;
-          color: black;
-        }
-      }
-      .link:hover {
-        text-decoration: underline;
-      }
-    }
-    .navbar-right {
-      width: 200px;
-      padding-right: 3vw;
-      display: flex;
-      justify-content: flex-end;
-      height: 30px;
-      .link {
-        margin-left: 10px;
-        margin-top: 15px;
-        margin-bottom: 0px;
-        color: black;
-        .small-head {
-          font-size: 13px;
-          color: black;
-        }
-      }
-      .link:hover {
-        text-decoration: underline;
-      }
-    }
-  }
-  .user-dashboard {
-    background-color: #212325;
-    color: white;
-    .user-form-layer-0 {
-      display: flex;
-      flex-direction: row;
-      padding: 20px;
-      .user-info-button {
-        max-height: 75px;
-        min-height: 75px;
-        max-width: 75px;
-        min-width: 75px;
-        margin-right: 2rem;
-        background-color: #4c4ce0;
-        color: white;
-      }
-      .user-info {
-        border: 1px solid white;
-        padding: 10px;
-      }
-      .user-edit {
-        border: 1px solid white;
-        .wrapper {
-          list-style-type: none;
-          padding: 0;
-          border-radius: 3px;
-        }
-        .form-row {
-          display: flex;
-          justify-content: flex-end;
-          padding: 0.5em;
-          label {
-            padding: 0.5em 1em 0.5em 0;
-            flex: 1;
-          }
-          input {
-            flex: 1;
-          }
-          input,
-          button {
-            padding: 0.5em;
-          }
-          button {
-            background: gray;
-            color: white;
-            border: 0;
-          }
-        }
-      }
-    }
-    .user-form-layer-1 {
-      display: flex;
-      flex-direction: row;
-      padding: 20px;
-      .categories-section {
-        border: 1px solid white;
-        border-radius: 10px;
-        align-items: center;
-        padding: 5px;
-        .categories {
-          display: flex;
-          flex-flow: row wrap;
-          align-items: center;
-          justify-content: center;
-          .category-child:nth-child(3n + 1) {
-            background-color: #4a4a4a;
-          }
-          .category-child:nth-child(3n + 2) {
-            background-color: #ff3751;
-          }
-          .category-child:nth-child(3n + 3) {
-            background-color: rgb(255, 143, 0);
-          } // .category-child:nth-child(4n+4) {
-          //   background-color:#7070e6;
-          // }
-          .category-child {
-            flex: 0 1 30%;
-            height: 100px;
-            min-width: 50px;
-            text-align: center;
-            margin: 10px 0 0 10px;
-            border-radius: 10px;
-            .half-child {
-              display: flex;
-              align-items: center;
-              justify-content: center;
-              align-self: center;
-              flex: 0 0 100%;
-              max-height: 50%;
-              min-height: 50%;
-              padding: 0.5em;
-              overflow: hidden;
+        margin-bottom: 40px;
+        display: flex;
+
+        .navbar-central {
+            width: calc(100vw - 200px - 250px);
+            display: flex;
+            justify-content: center;
+            height: 30px;
+
+            #head-link {
+                height: 30px;
+
+                #head {
+                    font-size: 16px;
+                    color: black;
+                    font-style: italic;
+                    height: 30px;
+                    width: 15vw;
+                    outline: none;
+                    border: none;
+                    background-color: white;
+                }
             }
-          }
         }
-      }
-      .submissions {
-        margin: 0 10px 0 10px;
-        border: 1px solid white;
-        border-radius: 10px;
-        width: 100%;
-        padding: 10px;
-        .algorithm-submissions {
-          border: 1px solid red;
+
+        .navbar-left {
+            width: 250px;
+            display: flex;
+            padding-left: 3vw;
+            height: 30px;
+
+            .link {
+                margin-right: 10px;
+                margin-top: 15px;
+                margin-bottom: 0px;
+                color: black;
+
+                .small-head {
+                    font-size: 13px;
+                    color: black;
+                }
+            }
+
+            .link:hover {
+                text-decoration: underline;
+            }
         }
-      }
+
+        .navbar-right {
+            width: 200px;
+            padding-right: 3vw;
+            display: flex;
+            justify-content: flex-end;
+            height: 30px;
+
+            .link {
+                margin-left: 10px;
+                margin-top: 15px;
+                margin-bottom: 0px;
+                color: black;
+
+                .small-head {
+                    font-size: 13px;
+                    color: black;
+                }
+            }
+
+            .link:hover {
+                text-decoration: underline;
+            }
+        }
     }
-  }
-  #homepage {
-    display: flex;
-    flex-direction: column;
-    #random-question-container {
-      height: 300px;
-      display: flex;
-      justify-content: center;
-      #question-column-container {
+
+    .user-dashboard {
+        background-color: #212325;
+        color: white;
+
+        .user-form-layer-0 {
+            display: flex;
+            flex-direction: row;
+            padding: 20px;
+
+            .user-info-button {
+                max-height: 75px;
+                min-height: 75px;
+                max-width: 75px;
+                min-width: 75px;
+                margin-right: 2rem;
+                background-color: #4c4ce0;
+                color: white;
+            }
+
+            .user-info {
+                border: 1px solid white;
+                padding: 10px;
+            }
+
+            .user-edit {
+                border: 1px solid white;
+
+                .wrapper {
+                    list-style-type: none;
+                    padding: 0;
+                    border-radius: 3px;
+                }
+
+                .form-row {
+                    display: flex;
+                    justify-content: flex-end;
+                    padding: 0.5em;
+
+                    label {
+                        padding: 0.5em 1em 0.5em 0;
+                        flex: 1;
+                    }
+
+                    input {
+                        flex: 1;
+                    }
+
+                    input,
+                    button {
+                        padding: 0.5em;
+                    }
+
+                    button {
+                        background: gray;
+                        color: white;
+                        border: 0;
+                    }
+                }
+            }
+        }
+
+        .user-form-layer-1 {
+            display: flex;
+            flex-direction: row;
+            padding: 20px;
+
+            .categories-section {
+                border: 1px solid white;
+                border-radius: 10px;
+                align-items: center;
+                padding: 5px;
+
+                .categories {
+                    display: flex;
+                    flex-flow: row wrap;
+                    align-items: center;
+                    justify-content: center;
+
+                    .category-child:nth-child(3n + 1) {
+                        background-color: #4a4a4a;
+                    }
+
+                    .category-child:nth-child(3n + 2) {
+                        background-color: #ff3751;
+                    }
+
+                    .category-child:nth-child(3n + 3) {
+                        background-color: rgb(255, 143, 0);
+                    } // .category-child:nth-child(4n+4) {
+                    //   background-color:#7070e6;
+                    // }
+                    .category-child {
+                        flex: 0 1 30%;
+                        height: 100px;
+                        min-width: 50px;
+                        text-align: center;
+                        margin: 10px 0 0 10px;
+                        border-radius: 10px;
+
+                        .half-child {
+                            display: flex;
+                            align-items: center;
+                            justify-content: center;
+                            align-self: center;
+                            flex: 0 0 100%;
+                            max-height: 50%;
+                            min-height: 50%;
+                            padding: 0.5em;
+                            overflow: hidden;
+                        }
+                    }
+                }
+            }
+
+            .submissions {
+                margin: 0 10px 0 10px;
+                border: 1px solid white;
+                border-radius: 10px;
+                width: 100%;
+                padding: 10px;
+
+                .algorithm-submissions {
+                    border: 1px solid red;
+                }
+            }
+        }
+    }
+
+    #homepage {
         display: flex;
         flex-direction: column;
-        justify-content: center;
-        font-size: 20px;
-        line-height: 40px;
-        #randomQuestionLink {
-          color: black;
-          text-decoration: underline;
-        }
-      }
-    }
-    #homepage-bottom-container {
-      display: flex;
-      #sidebar {
-        width: 150px;
-        margin-top: 3vh;
-        padding-left: 20px;
-        button {
-          margin-bottom: 20px;
-          border: none;
-          background-color: white;
-          color: black;
-          padding: 0px;
-          font-size: 13px;
-          outline: none;
-          cursor: pointer;
-        }
-      }
-      #box-container {
-        display: flex;
-        flex-wrap: wrap;
-        width: calc(100vw - 150px);
-        .box {
-          margin-left: 1.5vw;
-          margin-right: 1.5vw;
-          margin-top: 2vh;
-          margin-bottom: 2vh;
-          width: 25vw;
-          height: 200px;
-          padding: 15px;
-          .title {
-            margin-bottom: 30px;
-            font-size: 18px;
-            text-align: center;
-            border: 1px solid black;
-            margin-left: 4vw;
-            margin-right: 4vw;
-          }
-          .questions {
-            height: 150px;
-            font-size: 13px;
-            line-height: 17px;
-            margin-left: 5vw;
-            .question-link {
-              text-decoration: underline;
-              color: black;
+
+        #random-question-container {
+            height: 300px;
+            display: flex;
+            justify-content: center;
+
+            #question-column-container {
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                font-size: 20px;
+                line-height: 40px;
+
+                #randomQuestionLink {
+                    color: black;
+                    text-decoration: underline;
+                }
             }
-          }
-          .description {
-            height: 150px;
-            font-size: 13px;
-            line-height: 18px;
-          }
         }
-      }
-      #difficulty-container {
-        display: flex;
-        flex-wrap: wrap;
-        width: calc(100vw - 150px);
-        .difficulty-box {
-          margin-left: 1.5vw;
-          margin-right: 1.5vw;
-          margin-top: 2vh;
-          margin-bottom: 2vh;
-          width: 25vw;
-          height: 200px;
-          padding: 15px;
-          .title {
-            margin-bottom: 30px;
-            font-size: 18px;
-            text-align: center;
-            border: 1px solid black;
-            margin-left: 4vw;
-            margin-right: 4vw;
-          }
-          .questions {
-            height: 150px;
-            font-size: 13px;
-            line-height: 17px;
-            margin-left: 5vw;
-            .question-link {
-              text-decoration: underline;
-              color: black;
-            }
-          }
-        }
-      }
-    }
-  }
-  .repl-container {
-    height: calc(100vh - 87px);
-    padding-bottom: 5px;
-    display: flex;
-    width: 100vw;
-    .left-container {
-      height: calc(100vh - 70px - 40px);
-      padding-left: 40px;
-      padding-right: 13px;
-      width: 40vw;
-      display: flex;
-      flex-direction: column;
-      .question-name {
-        height: 30px;
-        font-style: italic;
-        margin-bottom: 10px;
-      }
-      .instructions-button-container {
-        height: 30px;
-        width: calc(40vw - 53px);
-        button {
-          background-color: white;
-          padding: 0px;
-          color: black;
-          border-top-left-radius: 3px;
-          border-top-right-radius: 3px;
-          border-bottom-left-radius: 0px;
-          border-bottom-right-radius: 0px;
-          height: 30px;
-          outline: none;
-          width: 100px;
-          border: none;
-          font-size: 13px;
-        }
-      }
-      .instructions-shell {
-        height: calc(100vh - 70px - 40px - 30px - 40px);
-        border: 1px solid black;
-        width: calc(40vw - 53px);
-        padding: 15px;
-        font-size: 13px;
-        line-height: 25px;
-        overflow-y: scroll;
-      }
-    }
-    .right-container {
-      height: calc(100vh - 70px - 40px);
-      display: flex;
-      padding-right: 40px;
-      padding-left: 13px;
-      width: 60vw;
-      flex-direction: column;
-      .language-buttons-container {
-        height: 30px;
-        display: flex;
-        justify-content: flex-end;
-        width: calc(60vw - 53px);
-        margin-bottom: 10px;
-        button {
-          background-color: white;
-          padding: 0px;
-          color: black;
-          border: 1px solid black;
-          border-radius: 0px;
-          height: 30px;
-          outline: none;
-          width: 100px;
-          font-size: 13px;
-          margin-right: 15px;
-        }
-      }
-      .solution-button-container {
-        height: 30px;
-        width: calc(60vw - 53px);
-        button {
-          background-color: white;
-          padding: 0px;
-          color: black;
-          border-top-left-radius: 3px;
-          border-top-right-radius: 3px;
-          border-bottom-left-radius: 0px;
-          border-bottom-right-radius: 0px;
-          height: 30px;
-          outline: none;
-          width: 100px;
-          border: none;
-          font-size: 13px;
-        }
-      }
-      .top {
-        height: calc(
-           ((100vh - 70px - 40px - 30px - 10px - 30px) * 0.6) + 15px
-        );
-        padding-bottom: 15px;
-        .code-editor {
-          height: calc(
-             ((100vh - 70px - 40px - 30px - 10px - 30px) * 0.6) - 30px - 15px
-          );
-          .ace-editor {
-            border: 1px solid black;
-            display: relative;
-            height: calc(
-               ((100vh - 70px - 40px - 30px - 10px - 30px) * 0.6) - 30px - 15px
-            ) !important;
-            .ace_print-margin {
-              visibility: hidden !important;
-            }
-          }
-        }
-        .run-button-container {
-          height: 30px;
-          button {
-            background-color: white;
-            padding: 0px;
-            color: black;
-            border-top: none;
-            border-radius: 0px;
-            border-left: 1px solid black;
-            border-right: 1px solid black;
-            border-bottom: 1px solid black;
-            border-bottom-left-radius: 0px;
-            border-bottom-right-radius: 10px;
-            height: 30px;
-            outline: none;
-            width: 100px;
-            font-size: 13px;
-          }
-        }
-      }
-      .bottom {
-        height: calc( (100vh - 70px - 40px - 30px - 10px - 30px) * 0.4);
-        .results-button-container {
-          height: 30px;
-          width: calc(60vw - 53px);
-          button {
-            background-color: white;
-            padding: 0px;
-            color: black;
-            border-top-left-radius: 3px;
-            border-top-right-radius: 3px;
-            border-bottom-left-radius: 0px;
-            border-bottom-right-radius: 0px;
-            height: 30px;
-            outline: none;
-            width: 100px;
-            border: none;
-            font-size: 13px;
-          }
-        }
-        .scroll-viewer {
-          padding: 15px;
-          border: 1px solid black;
-          height: calc(
-             ((100vh - 70px - 40px - 30px - 10px - 30px) * 0.4) - 30px
-          );
-          overflow: scroll;
-        }
-        .bottom-code-editor {
-          height: calc(
-             ((100vh - 70px - 40px - 30px - 10px - 30px) * 0.4) - 30px
-          );
-          .bottom-ace-editor {
-            border: 1px solid black;
-            display: relative;
-            height: calc(
-               ((100vh - 70px - 40px - 30px - 10px - 30px) * 0.4) - 30px
-            ) !important;
-            .ace_print-margin {
-              visibility: hidden !important;
-            }
-          }
-        }
-      }
-    }
-  }
-  #submission-page {
-    height: calc(100vh - 70px);
-    padding-bottom: 40px;
-    width: 100vw;
-    padding-left: 40px;
-    padding-right: 40px;
-    #submission-control-buttons-container {
-      height: 60px;
-      padding-bottom: 10px;
-      display: flex;
-      align-items: flex-end;
-      button {
-        margin-left: 20px;
-        border: 1px solid black;
-        border-radius: 0px;
-        background-color: white;
-        color: black;
-        font-size: 13px;
-        outline: none;
-        cursor: pointer;
-      }
-    }
-    #question-info {
-      display: flex;
-      height: calc((100vh - 70px - 40px - 60px) * 0.4);
-      #submission-info-form-container {
-        width: calc((100vw - 40px - 40px) * 0.45);
-        font-size: 13px;
-        padding-right: 30px;
-        .input-row {
-          height: calc((100vh - 70px - 40px - 60px) * 0.4 / 5);
-          width: calc(((100vw - 40px - 40px) * 0.45) - 30px);
-          margin-left: 0px !important;
-          margin-right: 0px;
-          padding-top: 10px;
-          label {
-            margin-bottom: 5px;
-          }
-          select {
-            border: 1px solid black;
-            width: calc(((100vw - 40px - 40px) * 0.45) - 30px);
-            outline: none;
-          }
-          input {
-            border: 1px solid black;
-            width: calc(((100vw - 40px - 40px) * 0.45) - 30px);
-            outline: none;
-          }
-        }
-      }
-      #description-container {
-        width: calc((100vw - 40px - 40px) * 0.55);
-        #description-title {
-          padding-top: 8px;
-          font-size: 13px;
-          padding-left: 5px;
-          padding-bottom: 8px;
-          border: 1px solid black;
-          height: 30px;
-        }
-        textarea {
-          font-size: 13px;
-          height: calc(((100vh - 70px - 40px - 60px) * 0.4) - 30px);
-          padding: 10px;
-          width: calc((100vw - 40px - 40px) * 0.55);
-          border-top: none;
-          border-bottom: 1px solid black;
-          border-left: 1px solid black;
-          border-right: 1px solid black;
-        }
-      }
-    }
-    #solution-test-container {
-      display: flex;
-      padding-top: 30px;
-      height: calc((100vh - 70px - 40px - 60px) * 0.6);
-      width: calc(100vw - 40px - 40px);
-      #submission-solution {
-        width: calc((100vw - 40px - 40px) * 0.5);
-        height: calc(((100vh - 70px - 40px - 60px) * 0.6) - 30px);
-        padding-right: 15px;
-        #validate-button-container {
-          height: 30px;
-          button {
-            background-color: white;
-            padding: 0px;
-            color: black;
-            border-bottom: none;
-            border-radius: 0px;
-            border-left: 1px solid black;
-            border-right: 1px solid black;
-            border-top: 1px solid black;
-            height: 30px;
-            outline: none;
-            width: 100px;
-            font-size: 11px;
-          }
-        }
-        #submission-code-editor {
-          height: calc(((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px);
-          .ace-editor {
-            border: 1px solid black;
-            display: relative;
-            height: calc(
-               ((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px
-            ) !important;
-            .ace_print-margin {
-              visibility: hidden !important;
-            }
-            .ace_content {
-              height: calc(
-                 ((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px
-              ) !important;
-            }
-          }
-        }
-      }
-      #test-solution {
-        width: calc((100vw - 40px - 40px) * 0.5);
-        height: calc(((100vh - 70px - 40px - 60px) * 0.6) - 30px);
-        padding-left: 15px;
-        #tests-button-container {
-          height: 30px;
-          width: calc(((100vw - 40px - 40px) * 0.5) - 15px);
-          button {
-            background-color: white;
-            color: black;
-            border-radius: 0px;
-            height: 30px;
-            outline: none;
-            border: none;
-            font-size: 13px;
-            border-bottom: none;
-          }
-        }
-        .submission-test-code-editor {
-          font-size: 13px;
-          height: calc(((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px);
-          width: calc(((100vw - 40px - 40px) * 0.5) - 15px);
-          .ace-test-editor {
-            border: 1px solid black;
-            display: relative;
-            height: calc(
-               ((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px
-            ) !important;
-            .ace_print-margin {
-              visibility: hidden !important;
-            }
-            #test-solution {
-              width: calc((100vw - 40px - 40px) * 0.5);
-              height: calc(((100vh - 70px - 40px - 60px) * 0.6) - 30px);
-              padding-left: 15px;
-              #tests-button-container {
-                height: 30px;
-                width: calc(((100vw - 40px - 40px) * 0.5) - 15px);
+
+        #homepage-bottom-container {
+            display: flex;
+
+            #sidebar {
+                width: 150px;
+                margin-top: 3vh;
+                padding-left: 20px;
+
                 button {
-                  background-color: white;
-                  color: black;
-                  border-radius: 0px;
-                  height: 30px;
-                  outline: none;
-                  border: none;
-                  font-size: 13px;
-                  border-bottom: none;
+                    margin-bottom: 20px;
+                    border: none;
+                    background-color: white;
+                    color: black;
+                    padding: 0px;
+                    font-size: 13px;
+                    outline: none;
+                    cursor: pointer;
                 }
-              }
-              .submission-test-code-editor {
-                font-size: 13px;
-                height: calc(
-                   ((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px
-                );
-                width: calc(((100vw - 40px - 40px) * 0.5) - 15px);
-                .ace-test-editor {
-                  border: 1px solid black;
-                  display: relative;
-                  height: calc(
-                     ((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px
-                  ) !important;
-                  .ace_print-margin {
-                    visibility: hidden !important;
-                  }
-                  .ace_content {
-                    height: calc(
-                       ((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px
-                    ) !important;
-                  }
-                }
-              }
-              .scroll-viewer {
-                padding: 15px;
-                border: 1px solid black;
-                height: calc(
-                   ((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px
-                );
-                width: calc(((100vw - 40px - 40px) * 0.5) - 15px);
-                overflow: scroll;
-              }
-              .ace_content {
-                height: calc(
-                   ((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px
-                ) !important;
-              }
             }
-          }
+
+            #box-container {
+                display: flex;
+                flex-wrap: wrap;
+                width: calc(100vw - 150px);
+
+                .box {
+                    margin-left: 1.5vw;
+                    margin-right: 1.5vw;
+                    margin-top: 2vh;
+                    margin-bottom: 2vh;
+                    width: 25vw;
+                    height: 200px;
+                    padding: 15px;
+
+                    .title {
+                        margin-bottom: 30px;
+                        font-size: 18px;
+                        text-align: center;
+                        border: 1px solid black;
+                        margin-left: 4vw;
+                        margin-right: 4vw;
+                    }
+
+                    .questions {
+                        height: 150px;
+                        font-size: 13px;
+                        line-height: 17px;
+                        margin-left: 5vw;
+
+                        .question-link {
+                            text-decoration: underline;
+                            color: black;
+                        }
+                    }
+
+                    .description {
+                        height: 150px;
+                        font-size: 13px;
+                        line-height: 18px;
+                    }
+                }
+            }
+
+            #difficulty-container {
+                display: flex;
+                flex-wrap: wrap;
+                width: calc(100vw - 150px);
+
+                .difficulty-box {
+                    margin-left: 1.5vw;
+                    margin-right: 1.5vw;
+                    margin-top: 2vh;
+                    margin-bottom: 2vh;
+                    width: 25vw;
+                    height: 200px;
+                    padding: 15px;
+
+                    .title {
+                        margin-bottom: 30px;
+                        font-size: 18px;
+                        text-align: center;
+                        border: 1px solid black;
+                        margin-left: 4vw;
+                        margin-right: 4vw;
+                    }
+
+                    .questions {
+                        height: 150px;
+                        font-size: 13px;
+                        line-height: 17px;
+                        margin-left: 5vw;
+
+                        .question-link {
+                            text-decoration: underline;
+                            color: black;
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
+
+    .repl-container {
+        height: calc(100vh - 87px);
+        padding-bottom: 5px;
+        display: flex;
+        width: 100vw;
+
+        .left-container {
+            height: calc(100vh - 70px - 40px);
+            padding-left: 40px;
+            padding-right: 13px;
+            width: 40vw;
+            display: flex;
+            flex-direction: column;
+
+            .question-name {
+                height: 30px;
+                font-style: italic;
+                margin-bottom: 10px;
+            }
+
+            .instructions-button-container {
+                height: 30px;
+                width: calc(40vw - 53px);
+
+                button {
+                    background-color: white;
+                    padding: 0px;
+                    color: black;
+                    border-top-left-radius: 3px;
+                    border-top-right-radius: 3px;
+                    border-bottom-left-radius: 0px;
+                    border-bottom-right-radius: 0px;
+                    height: 30px;
+                    outline: none;
+                    width: 100px;
+                    border: none;
+                    font-size: 13px;
+                }
+            }
+
+            .instructions-shell {
+                height: calc(100vh - 70px - 40px - 30px - 40px);
+                border: 1px solid black;
+                width: calc(40vw - 53px);
+                padding: 15px;
+                font-size: 13px;
+                line-height: 25px;
+                overflow-y: scroll;
+            }
+        }
+
+        .right-container {
+            height: calc(100vh - 70px - 40px);
+            display: flex;
+            padding-right: 40px;
+            padding-left: 13px;
+            width: 60vw;
+            flex-direction: column;
+
+            .language-buttons-container {
+                height: 30px;
+                display: flex;
+                justify-content: flex-end;
+                width: calc(60vw - 53px);
+                margin-bottom: 10px;
+
+                button {
+                    background-color: white;
+                    padding: 0px;
+                    color: black;
+                    border: 1px solid black;
+                    border-radius: 0px;
+                    height: 30px;
+                    outline: none;
+                    width: 100px;
+                    font-size: 13px;
+                    margin-right: 15px;
+                }
+            }
+
+            .solution-button-container {
+                height: 30px;
+                width: calc(60vw - 53px);
+
+                button {
+                    background-color: white;
+                    padding: 0px;
+                    color: black;
+                    border-top-left-radius: 3px;
+                    border-top-right-radius: 3px;
+                    border-bottom-left-radius: 0px;
+                    border-bottom-right-radius: 0px;
+                    height: 30px;
+                    outline: none;
+                    width: 100px;
+                    border: none;
+                    font-size: 13px;
+                }
+            }
+
+            .top {
+                height: calc( ((100vh - 70px - 40px - 30px - 10px - 30px) * 0.6) + 15px );
+                padding-bottom: 15px;
+
+                .code-editor {
+                    height: calc( ((100vh - 70px - 40px - 30px - 10px - 30px) * 0.6) - 30px - 15px );
+
+                    .ace-editor {
+                        border: 1px solid black;
+                        display: relative;
+                        height: calc( ((100vh - 70px - 40px - 30px - 10px - 30px) * 0.6) - 30px - 15px ) !important;
+
+                        .ace_print-margin {
+                            visibility: hidden !important;
+                        }
+                    }
+                }
+
+                .run-button-container {
+                    height: 30px;
+
+                    button {
+                        background-color: white;
+                        padding: 0px;
+                        color: black;
+                        border-top: none;
+                        border-radius: 0px;
+                        border-left: 1px solid black;
+                        border-right: 1px solid black;
+                        border-bottom: 1px solid black;
+                        border-bottom-left-radius: 0px;
+                        border-bottom-right-radius: 10px;
+                        height: 30px;
+                        outline: none;
+                        width: 100px;
+                        font-size: 13px;
+                    }
+                }
+            }
+
+            .bottom {
+                height: calc( (100vh - 70px - 40px - 30px - 10px - 30px) * 0.4);
+
+                .results-button-container {
+                    height: 30px;
+                    width: calc(60vw - 53px);
+
+                    button {
+                        background-color: white;
+                        padding: 0px;
+                        color: black;
+                        border-top-left-radius: 3px;
+                        border-top-right-radius: 3px;
+                        border-bottom-left-radius: 0px;
+                        border-bottom-right-radius: 0px;
+                        height: 30px;
+                        outline: none;
+                        width: 100px;
+                        border: none;
+                        font-size: 13px;
+                    }
+                }
+
+                .scroll-viewer {
+                    padding: 15px;
+                    border: 1px solid black;
+                    height: calc( ((100vh - 70px - 40px - 30px - 10px - 30px) * 0.4) - 30px );
+                    overflow: scroll;
+                }
+
+                .bottom-code-editor {
+                    height: calc( ((100vh - 70px - 40px - 30px - 10px - 30px) * 0.4) - 30px );
+
+                    .bottom-ace-editor {
+                        border: 1px solid black;
+                        display: relative;
+                        height: calc( ((100vh - 70px - 40px - 30px - 10px - 30px) * 0.4) - 30px ) !important;
+
+                        .ace_print-margin {
+                            visibility: hidden !important;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #submission-page {
+        height: calc(100vh - 70px);
+        padding-bottom: 40px;
+        width: 100vw;
+        padding-left: 40px;
+        padding-right: 40px;
+
+        #submission-control-buttons-container {
+            height: 60px;
+            padding-bottom: 10px;
+            display: flex;
+            align-items: flex-end;
+
+            button {
+                margin-left: 20px;
+                border: 1px solid black;
+                border-radius: 0px;
+                background-color: white;
+                color: black;
+                font-size: 13px;
+                outline: none;
+                cursor: pointer;
+            }
+        }
+
+        #question-info {
+            display: flex;
+            height: calc((100vh - 70px - 40px - 60px) * 0.4);
+
+            #submission-info-form-container {
+                width: calc((100vw - 40px - 40px) * 0.45);
+                font-size: 13px;
+                padding-right: 30px;
+
+                .input-row {
+                    height: calc((100vh - 70px - 40px - 60px) * 0.4 / 5);
+                    width: calc(((100vw - 40px - 40px) * 0.45) - 30px);
+                    margin-left: 0px !important;
+                    margin-right: 0px;
+                    padding-top: 10px;
+
+                    label {
+                        margin-bottom: 5px;
+                    }
+
+                    select {
+                        border: 1px solid black;
+                        width: calc(((100vw - 40px - 40px) * 0.45) - 30px);
+                        outline: none;
+                    }
+
+                    input {
+                        border: 1px solid black;
+                        width: calc(((100vw - 40px - 40px) * 0.45) - 30px);
+                        outline: none;
+                    }
+                }
+            }
+
+            #description-container {
+                width: calc((100vw - 40px - 40px) * 0.55);
+
+                #description-title {
+                    padding-top: 8px;
+                    font-size: 13px;
+                    padding-left: 5px;
+                    padding-bottom: 8px;
+                    border: 1px solid black;
+                    height: 30px;
+                }
+
+                textarea {
+                    font-size: 13px;
+                    height: calc(((100vh - 70px - 40px - 60px) * 0.4) - 30px);
+                    padding: 10px;
+                    width: calc((100vw - 40px - 40px) * 0.55);
+                    border-top: none;
+                    border-bottom: 1px solid black;
+                    border-left: 1px solid black;
+                    border-right: 1px solid black;
+                }
+            }
+        }
+
+        #solution-test-container {
+            display: flex;
+            padding-top: 30px;
+            height: calc((100vh - 70px - 40px - 60px) * 0.6);
+            width: calc(100vw - 40px - 40px);
+
+            #submission-solution {
+                width: calc((100vw - 40px - 40px) * 0.5);
+                height: calc(((100vh - 70px - 40px - 60px) * 0.6) - 30px);
+                padding-right: 15px;
+
+                #validate-button-container {
+                    height: 30px;
+
+                    button {
+                        background-color: white;
+                        padding: 0px;
+                        color: black;
+                        border-bottom: none;
+                        border-radius: 0px;
+                        border-left: 1px solid black;
+                        border-right: 1px solid black;
+                        border-top: 1px solid black;
+                        height: 30px;
+                        outline: none;
+                        width: 100px;
+                        font-size: 11px;
+                    }
+                }
+
+                #submission-code-editor {
+                    height: calc(((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px);
+
+                    .ace-editor {
+                        border: 1px solid black;
+                        display: relative;
+                        height: calc( ((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px ) !important;
+
+                        .ace_print-margin {
+                            visibility: hidden !important;
+                        }
+
+                        .ace_content {
+                            height: calc( ((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px ) !important;
+                        }
+                    }
+                }
+            }
+
+            #test-solution {
+                width: calc((100vw - 40px - 40px) * 0.5);
+                height: calc(((100vh - 70px - 40px - 60px) * 0.6) - 30px);
+                padding-left: 15px;
+
+                #tests-button-container {
+                    height: 30px;
+                    width: calc(((100vw - 40px - 40px) * 0.5) - 15px);
+
+                    button {
+                        background-color: white;
+                        color: black;
+                        border-radius: 0px;
+                        height: 30px;
+                        outline: none;
+                        border: none;
+                        font-size: 13px;
+                        border-bottom: none;
+                    }
+                }
+
+                #submission-test-code-editor {
+                    font-size: 13px;
+                    height: calc(((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px);
+                    width: calc(((100vw - 40px - 40px) * 0.5) - 15px);
+
+                    .ace-test-editor {
+                        border: 1px solid black;
+                        display: relative;
+                        height: calc( ((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px ) !important;
+
+                        .ace_print-margin {
+                            visibility: hidden !important;
+                        }
+                    }
+                }
+
+                .scroll-viewer {
+                    padding: 15px;
+                    border: 1px solid black;
+                    height: calc( ((100vh - 70px - 40px - 60px) * 0.6) - 30px - 30px );
+                    width: calc(((100vw - 40px - 40px) * 0.5) - 15px);
+                    overflow: scroll;
+                }
+
+  
+            }
+        }
+    }
 }
 
 .custom-right {
-  position: relative;
-  z-index: 1;
+    position: relative;
+    z-index: 1;
 }
 
 .modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  overflow: auto;
-  background-color: rgb(0, 0, 0);
-  /* RGBa with 0.6 opacity */
-  background-color: rgba(0, 0, 0, 0.6);
-  /* For IE 5.5 - 7*/
-  filter: progid:DXImageTransform.Microsoft.gradient(
-      startColorstr=#99000000,
-      endColorstr=#99000000
-    );
-  /* For IE 8*/
-  border-radius: 4px;
-  outline: none;
-  padding: 20px;
-  display: block;
-  opacity: 1;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    overflow: auto;
+    background-color: rgb(0, 0, 0);
+
+    /* RGBa with 0.6 opacity */
+    background-color: rgba(0, 0, 0, 0.6);
+
+    /* For IE 5.5 - 7*/
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr=#99000000, endColorstr=#99000000 );
+
+    /* For IE 8*/
+    border-radius: 4px;
+    outline: none;
+    padding: 20px;
+    display: block;
+    opacity: 1;
 }
 
 .oauth-box {
-  margin-top: 10%;
-  display: flex;
-  justify-content: center;
+    margin-top: 10%;
+    display: flex;
+    justify-content: center;
 
-  .login-box {
-    background-color: white;
-    border: 1px solid black;
-    filter: hue-rotate(50%);
+    .login-box {
+        background-color: white;
+        border: 1px solid black;
+        filter: hue-rotate(50%);
 
-    .error-handled {
-      font-size: 0.6em;
-      display: flex;
-      justify-content: center;
-      color: red;
-    }
+        .error-handled {
+            font-size: 0.6em;
+            display: flex;
+            justify-content: center;
+            color: red;
+        }
 
-    .inputs {
-      margin-bottom: 0;
-    }
+        .inputs {
+            margin-bottom: 0;
+        }
 
-    .oauth-buttons {
-      display: flex;
-      justify-content: center;
-      margin-top: 6;
-      margin-bottom: 2;
+        .oauth-buttons {
+            display: flex;
+            justify-content: center;
+            margin-top: 6;
+            margin-bottom: 2;
+        }
+
+        .not-user-sign-up {
+            font-size: 0.8em;
+            display: flex;
+            justify-content: center;
+        }
+
+        .toggle-view-auth-sign {
+            color: blue;
+        }
+
+        .toggle-view-auth-sign:hover {
+            cursor: pointer;
+            margin: 4;
+        }
     }
-    .not-user-sign-up {
-      font-size: 0.8em;
-      display: flex;
-      justify-content: center;
-    }
-    .toggle-view-auth-sign {
-      color: blue;
-    }
-    .toggle-view-auth-sign:hover {
-      cursor: pointer;
-      margin: 4;
-    }
-  }
 }
 
 .question-chat {
-  margin-bottom: 40px;
-  margin-top: 5px;
-  display: row;
-  .posted-chat-container {
-    //height: 280px;
-    // border: 1px solid black;
-    line-height: 25px;
-    margin-left: 41px;
-    margin-right: 41px;
-    font-size: 13px;
-    p {
-      margin: 2px;
+    margin-bottom: 40px;
+    margin-top: 5px;
+    display: row;
+
+    .posted-chat-container {
+        //height: 280px;
+        // border: 1px solid black;
+        line-height: 25px;
+        margin-left: 41px;
+        margin-right: 41px;
+        font-size: 13px;
+
+        p {
+            margin: 2px;
+        }
+
+        .posted-comments {
+            margin: 7px;
+        }
+
+        .user-name-comment {
+            display: inline-block;
+            margin-top: 15px;
+            margin-left: 14px;
+            color: rgb(62, 61, 61);
+            font-weight: bold;
+        }
+
+        .posted-date {
+            font-size: 10px;
+        }
+
+        .user-comment {
+            margin-top: 5px;
+            margin-bottom: 5px;
+            margin-left: 40px;
+            margin-right: 40px;
+
+            button {
+                font-size: 8px;
+            }
+        }
     }
-    .posted-comments {
-      margin: 7px;
+
+    .post-chat-container {
+        height: 96px;
+
+        //border: 1px solid black;
+        line-height: 25px;
+        margin-left: 41px;
+        margin-right: 41px;
+        margin-bottom: 20px;
     }
-    .user-name-comment {
-      display: inline-block;
-      margin-top: 15px;
-      margin-left: 14px;
-      color: rgb(62, 61, 61);
-      font-weight: bold;
+
+    textarea {
+        display: block;
+        width: 98.57%;
+        margin: 7px;
     }
-    .posted-date {
-      font-size: 10px;
+
+    button {
+        display: inline-block;
+        margin: 7px;
+        border-radius: 0;
     }
-    .user-comment {
-      margin-top: 5px;
-      margin-bottom: 5px;
-      margin-left: 40px;
-      margin-right: 40px;
-      button {
-        font-size: 8px;
-      }
-    }
-  }
-  .post-chat-container {
-    height: 96px;
-    //border: 1px solid black;
-    line-height: 25px;
-    margin-left: 41px;
-    margin-right: 41px;
-    margin-bottom: 20px;
-  }
-  textarea {
-    display: block;
-    width: 98.57%;
-    margin: 7px;
-  }
-  button {
-    display: inline-block;
-    margin: 7px;
-    border-radius: 0;
-  }
 }

--- a/client/store/algorithm-validation-input.js
+++ b/client/store/algorithm-validation-input.js
@@ -28,7 +28,6 @@ export const postAlgorithmValidationInput = (submission, user) => {
             })
             .then(res => {
                 const results = res.data
-                console.log("FRONT END", results)
                 dispatch(setValidationResult(results.rawOutput))
                 dispatch(setValidationCustomResult(results.testCasesArr))
             })

--- a/client/store/questions.js
+++ b/client/store/questions.js
@@ -30,6 +30,17 @@ export const fetchQuestions = () => {
     }
 }
 
+export const postUserAlgorithmQuestion = questionSubmission => {
+    return function thunk(dispatch) {
+        axios
+            .post('/api/questions', questionSubmission)
+            .then((questionSaved) => {
+                console.log('QUESTION SAVED', questionSaved)
+            })
+            .catch(console.err)
+    }
+}
+
 /**
  * REDUCER
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -4501,15 +4501,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4519,6 +4510,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -8955,15 +8955,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -8989,6 +8980,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/script/seed.js
+++ b/script/seed.js
@@ -91,6 +91,7 @@ async function seed() {
   const questions = await Promise.all([
     Question.create({
       name: 'BST Construction',
+      published: true,
       description:
         'Write a Binary Search Tree (BST) class named "BST". The BST class should have a "value" property set to be an integer, as well as "left" and "right" properties, both of which should point to either the None (null) value or to another BST. A node is said to be a BST node if and only if it satisfies the BST property: its value is strictly greater than the values of every node to its left; its value is less than or equal to the values of every node to its right; and both of its children nodes are either BST nodes themselves or None (null) values. The BST class should support three methods, viz., "insert", "contains", and "remove". The "contains" method return a boolean value indicating whether the value is contained in the BST tree or not. The "remove" method should only remove the first instance of the target value.',
       javascriptSolution: `
@@ -721,6 +722,7 @@ if __name__ == "__main__":
     }),
     Question.create({
       name: 'BST Traversal',
+      published: true,
       description:
         'Write three functions, viz., "inOrderTraverse", "preOrderTraverse", and "postOrderTraverse", that take in an empty array, traverse the BST, add its nodes\' values to the input array, and return that array. The three functions should traverse the BST using the in-order traversal, pre-order traversal, and post-order traversal techniques, respectively. You are given a BST data structure consisting of BST nodes. Each BST node has an integer value stored in a property called "value" and two children nodes stored in properties called "left" ani "right," respectively. A node is said to be a BST node if and only if it satisfies the BST property: its value is strictly greater than the values of every node to its left; its value is less than or equal to the values of every node to its right; and both of its children nodes are either BST nodes themselves or None (null) values.',
       javascriptSolution: `
@@ -760,6 +762,7 @@ function postOrderTraverse(tree, array) {
     }),
     Question.create({
       name: 'Two Number Sum',
+      published: true,
       description: '',
       javascriptSolution: '',
       pythonSolution: '',
@@ -771,6 +774,7 @@ function postOrderTraverse(tree, array) {
     }),
     Question.create({
       name: 'Three Number Sum',
+      published: true,
       description: '',
       javascriptSolution: '',
       pythonSolution: '',
@@ -782,6 +786,7 @@ function postOrderTraverse(tree, array) {
     }),
     Question.create({
       name: 'Max SubsetSum No Adjacent',
+      published: true,
       description: '',
       javascriptSolution: '',
       pythonSolution: '',
@@ -793,6 +798,7 @@ function postOrderTraverse(tree, array) {
     }),
     Question.create({
       name: 'Max Sum Increasing Subsequence',
+      published: true,
       description: '',
       javascriptSolution: '',
       pythonSolution: '',
@@ -804,6 +810,7 @@ function postOrderTraverse(tree, array) {
     }),
     Question.create({
       name: 'Depth-first Search',
+      published: true,
       description: '',
       javascriptSolution: '',
       pythonSolution: '',
@@ -815,6 +822,7 @@ function postOrderTraverse(tree, array) {
     }),
     Question.create({
       name: 'Breadth-first Search',
+      published: true,
       description: '',
       javascriptSolution: '',
       pythonSolution: '',
@@ -826,6 +834,7 @@ function postOrderTraverse(tree, array) {
     }),
     Question.create({
       name: 'Binary Search',
+      published: true,
       description: '',
       javascriptSolution: '',
       pythonSolution: '',
@@ -837,6 +846,7 @@ function postOrderTraverse(tree, array) {
     }),
     Question.create({
       name: 'Search In Sorted Matrix',
+      published: true,
       description: '',
       javascriptSolution: '',
       pythonSolution: '',
@@ -848,6 +858,7 @@ function postOrderTraverse(tree, array) {
     }),
     Question.create({
       name: 'Shifted Binary Search',
+      published: true,
       description: '',
       javascriptSolution: '',
       pythonSolution: '',
@@ -859,6 +870,7 @@ function postOrderTraverse(tree, array) {
     }),
     Question.create({
       name: 'Bubble Sort',
+      published: true,
       description: '',
       javascriptSolution: '',
       pythonSolution: '',
@@ -870,6 +882,7 @@ function postOrderTraverse(tree, array) {
     }),
     Question.create({
       name: 'Insertion Sort',
+      published: true,
       description: '',
       javascriptSolution: '',
       pythonSolution: '',
@@ -881,6 +894,7 @@ function postOrderTraverse(tree, array) {
     }),
     Question.create({
       name: 'Heap Sort',
+      published: true,
       description: '',
       javascriptSolution: '',
       pythonSolution: '',

--- a/server/api/algorithm-execution-util.js
+++ b/server/api/algorithm-execution-util.js
@@ -2,7 +2,7 @@ const getTestCaseOutcomes = (rawOutputStr) => {
     const start = rawOutputStr.indexOf('*****Eventually the testCaseOutcomes')
     const end = rawOutputStr.indexOf('*****End the testCaseOutcomes')
     const testCaseStr = rawOutputStr.slice(start + 37, end - 1)
-    const revisedStdoutStr = rawOutputStr.slice(0, start - 1) + rawOutputStr.slice(end + 29)
+    const revisedStdoutStr = rawOutputStr.slice(0, start) + rawOutputStr.slice(end + 29)
     return {
         testCasesStr: testCaseStr,
         revisedStdoutStr: revisedStdoutStr

--- a/server/api/algorithm-execution.js
+++ b/server/api/algorithm-execution.js
@@ -5,8 +5,6 @@ const { exec } = require('child_process')
 const { getTestCaseOutcomes } = require('./algorithm-execution-util')
 const tmp = require('tmp')
 
-// todo: sanitize the code input
-
 module.exports = router
 router.post('/javascript', (req, res, next) => {
   req.body.algorithmContent =

--- a/server/api/questions.js
+++ b/server/api/questions.js
@@ -3,13 +3,19 @@ const { Question, Difficulty } = require('../db/models')
 module.exports = router
 
 router.get('/', (req, res, next) => {
-  Question.findAll({include: [Difficulty]})
-    .then(questions => res.json(questions))
-    .catch(next)
+    Question.findAll({ include: [Difficulty] })
+        .then(questions => res.json(questions))
+        .catch(next)
 })
 
 router.post('/', (req, res, next) => {
-  Question.create(req.body)
-    .then(question => res.json(question))
-    .catch(next)
+    if (req.body.id) {
+        //Question.find()
+    } else {
+        Question.create(req.body)
+            .then((questionCreated) => {
+                res.json(questionCreated)
+            })
+            .catch(next)
+    }
 })

--- a/server/db/models/question.js
+++ b/server/db/models/question.js
@@ -2,43 +2,40 @@ const Sequelize = require('sequelize')
 const db = require('../db')
 
 const Question = db.define('question', {
-  name: {
-    type: Sequelize.STRING,
-    unique: true,
-    allowNull: false
-  },
-  description: {
-    type: Sequelize.TEXT,
-    allowNull: false
-  },
-  javascriptSolution: {
-    type: Sequelize.TEXT,
-    allowNull: false
-  },
-  pythonSolution: {
-    type: Sequelize.TEXT,
-    allowNull: false
-  },
-  functionName: {
-    type: Sequelize.STRING,
-    allowNull: false
-  },
-  javascriptTestFile: {
-    type: Sequelize.TEXT,
-    allowNull: false
-  },
-  pythonTestFile: {
-    type: Sequelize.TEXT,
-    allowNull: false
-  },
-  jsWalkThrough: {
-    type: Sequelize.ARRAY(Sequelize.STRING(3000)),
-    defaultValue: ['']
-  },
-  jsSolutionWT: {
-    type: Sequelize.ARRAY(Sequelize.STRING(3000)),
-    defaultValue: ['']
-  }
+    name: {
+        type: Sequelize.STRING,
+        unique: true,
+        allowNull: false
+    },
+    description: {
+        type: Sequelize.TEXT,
+    },
+    javascriptSolution: {
+        type: Sequelize.TEXT,
+    },
+    pythonSolution: {
+        type: Sequelize.TEXT,
+    },
+    functionName: {
+        type: Sequelize.STRING,
+    },
+    javascriptTestFile: {
+        type: Sequelize.TEXT,
+    },
+    pythonTestFile: {
+        type: Sequelize.TEXT,
+    },
+    jsWalkThrough: {
+        type: Sequelize.ARRAY(Sequelize.STRING(3000)),
+        defaultValue: ['']
+    },
+    jsSolutionWT: {
+        type: Sequelize.ARRAY(Sequelize.STRING(3000)),
+        defaultValue: ['']
+    },
+    published: {
+        type: Sequelize.BOOLEAN,
+    }
 })
 
 module.exports = Question


### PR DESCRIPTION
1) user can save a new algorithm submission and work on it later. Now, only creating a new question linked to the user.
2) frontend empty field control for algorithm name and function name. If a user click validate without entering function name, "required" in red will be displayed next to function name input label. Same for saving algorithm into database without quesiton name 
3) improve validation error handling and display

-----
TODO,
1) a user can have multiple submission questions in the dashboard
2) a user can choose to create a new question in the dashboard or choose to work on an unfinished and unpublished question or modify a finished and published question.
3) implement algorithm validation control  (passing all test cases written by the user) before publishing. (Already has algorithm validation working, only need to implement the logic for the publish button)
4) python validation
5) different frontend and backend logic for processing existing question or new quesiton
6) unique question name validation error 